### PR TITLE
Added custom builders for days and weekdays in HijriMonthPicker()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 3.1.0
+
+- Added custom builders for days and weekdays in `HijriMonthPicker()`
+
 ## 3.0.0
 
 - Migrated to null safety

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -85,7 +85,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.1.0"
   intl:
     dependency: transitive
     description:

--- a/lib/src/hijri_calendar_builders.dart
+++ b/lib/src/hijri_calendar_builders.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:hijri/hijri_calendar.dart';
+
+class HijriCalendarBuilders {
+  const HijriCalendarBuilders({
+    this.weekdayBuilder,
+    this.dayBuilder,
+  });
+
+  /// Weekdays builder (Sat, Sun, ..)
+  final Widget Function(BuildContext context, String day)? weekdayBuilder;
+
+  /// Days builder (1, 2, ..)
+  final Widget Function(
+      BuildContext context, HijriCalendar day, bool isSelected)? dayBuilder;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hijri_picker
 description: Hijri calender to pick umm alqura dates support max & min dates.
-version: 3.0.0
+version: 3.1.0
 homepage: "https://github.com/ahmedoid/hijri_picker"
 
 environment:


### PR DESCRIPTION
Salam

This PR is for customizing the days and weekdays of the calendar picker `HijriMonthPicker()`

One can add event indicators for example

## Screenshots

![image](https://user-images.githubusercontent.com/7901330/132447540-ecaa7039-61f1-4346-93a4-f37760b1e505.png)

![image](https://user-images.githubusercontent.com/7901330/132448399-095391b6-d736-46a9-801e-91687d285b23.png)

## Usage

```dart
      HijriMonthPicker(
        builders: HijriCalendarBuilders(
          dayBuilder: (BuildContext context, HijriCalendar date, bool isSelected) { ... },
          weekdayBuilder: (BuildContext context, String text) { ... },
        ),
      )
```
Thank you