### PR TITLE
Pass weekday number to weekdayBuilder

### DIFF
--- a/lib/hijri_picker.dart
+++ b/lib/hijri_picker.dart
@@ -740,7 +740,7 @@ class HijriDayPicker extends StatelessWidget {
           ? ExcludeSemantics(
               child: Center(child: Text(weekday, style: headerStyle)),
             )
-          : builders.weekdayBuilder!(context, weekday);
+          : builders.weekdayBuilder!(context, weekday, i);
 
       result.add(weekdayWidget);
 

--- a/lib/src/hijri_calendar_builders.dart
+++ b/lib/src/hijri_calendar_builders.dart
@@ -7,8 +7,9 @@ class HijriCalendarBuilders {
     this.dayBuilder,
   });
 
-  /// Weekdays builder (Sat, Sun, ..)
-  final Widget Function(BuildContext context, String day)? weekdayBuilder;
+  /// Weekdays builder (day: Sun, Mon.., number: 0, 1..)
+  final Widget Function(
+      BuildContext context, String day, int number)? weekdayBuilder;
 
   /// Days builder (1, 2, ..)
   final Widget Function(


### PR DESCRIPTION
Sometimes special adjustments need to be made on weekdays. For example, changing the Hijri date after Sunset while keeping the weekday the same as Gregorian date. For these adjustments `String day` passed to the weekdayBuilder isn't enough. Weekday number can be very handy for these kind of adjustments. Here's an example:

```dart
HijriMonthPicker(
  builders: HijriCalendarBuilders(
    weekdayBuilder: (context, day, number) {
      MaterialLocalizations localizations = MaterialLocalizations.of(context);
      
      int adjustedWeekdayNumber = 0;
      
      if (isAfterDateStartTime(DateTime.now())) {
         adjustedWeekdayNumber -= 1;
      }

      int num = (number + adjustedWeekdayNumber) % 7;
      final String weekday = localizations.narrowWeekdays[num];

      return Center(
        child: Text(weekday),
      );
    },
  ),
),
```

This PR passes the weekday number to weekdayBuilder. This is a breaking change for those who use custom weekdayBuilders.